### PR TITLE
Corrigindo falha no coveralls quando é utilizado versões acima do Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
-				</configuration>
+				</configuration>				
 			</plugin>
 
 			<plugin>
@@ -41,6 +41,15 @@
 				<configuration>
 					<repoToken>FcI5KZ17XEwBdCeRJzWNBL7iRXxwOndd3</repoToken>
 				</configuration>
+
+				<dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.0</version>
+                    </dependency>
+                </dependencies>
+
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
-				</configuration>				
+				</configuration>
 			</plugin>
 
 			<plugin>
@@ -39,17 +39,16 @@
 				<artifactId>coveralls-maven-plugin</artifactId>
 				<version>4.3.0</version>
 				<configuration>
-					<repoToken>FcI5KZ17XEwBdCeRJzWNBL7iRXxwOndd3</repoToken>
+					<repoToken>${repoToken}</repoToken>
 				</configuration>
 
 				<dependencies>
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>2.3.0</version>
-                    </dependency>
-                </dependencies>
-
+					<dependency>
+						<groupId>javax.xml.bind</groupId>
+						<artifactId>jaxb-api</artifactId>
+						<version>2.3.0</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>


### PR DESCRIPTION
Quando utilizado alguma versão acima do Java 8, ocorre uma falha ao rodar o comando:
`mvn clean test jacoco:report coveralls:report`

Para solução, foi incluído uma dependência do jaxb-api dentro do coveralls.